### PR TITLE
Fixed XSS during file uploading time

### DIFF
--- a/src/js/views/uploader.js
+++ b/src/js/views/uploader.js
@@ -21,9 +21,9 @@ export class UploaderView extends View {
   initialize(files, lang, parent_id) {
       this.uploader = new Uploader();
 
-      for(let sanitize(file) of files) {
+      for(let file of files) {
           this.uploader.add(
-            new UploaderItem(file, lang, parent_id)
+            new UploaderItem(sanitize(file), lang, parent_id)
           );
       }
 

--- a/src/js/views/uploader.js
+++ b/src/js/views/uploader.js
@@ -3,6 +3,7 @@ import _ from "underscore";
 import { Uploader, UploaderItem } from "../models/uploader";
 import { View } from 'backbone';
 import Backbone from 'backbone';
+import { sanitize } from '../utils';
 
 import {
   mg_dispatcher,
@@ -20,7 +21,7 @@ export class UploaderView extends View {
   initialize(files, lang, parent_id) {
       this.uploader = new Uploader();
 
-      for(let file of files) {
+      for(let sanitize(file) of files) {
           this.uploader.add(
             new UploaderItem(file, lang, parent_id)
           );


### PR DESCRIPTION
### 📊 Metadata *
Fixed Xss
#### Bounty URL:https://www.huntr.dev/bounties/2-pypi-papermerge
### ⚙️ Description *
Frontend part for papermerge backend
### 💻 Technical Description *
unsanitized rendering of filename during the uploading time has caused this issue. 
### 🐛 Proof of Concept (PoC) *
![Screenshot from 2021-03-04 19-26-28](https://user-images.githubusercontent.com/43377443/109974456-99a33400-7d1f-11eb-81db-fe3165a86d2a.png)

### 👍 User Acceptance Testing (UAT)
file name taken during the uploading time has been sanitized , with the sanitize function available in the utils file of papermerge-js repo.